### PR TITLE
Use whatever version of JSON flask is using

### DIFF
--- a/keg_elements/forms/__init__.py
+++ b/keg_elements/forms/__init__.py
@@ -6,7 +6,6 @@ import inspect
 import logging
 
 import flask
-import flask.json as json  # ensure we use the right json package
 from flask_wtf import Form as BaseForm
 from keg.db import db
 import six
@@ -244,14 +243,9 @@ class Form(BaseForm):
     def after_init(self, args, kwargs):
         pass
 
-    def fields_todict(self, as_json=False, **json_kwargs):
-        """
-            Turns a form into dicts and lists with both data and errors for each field.
-        """
-        data = form_fields_to_dict(self)
-        if as_json:
-            return json.dumps(data, **json_kwargs)
-        return data
+    def fields_todict(self):
+        """Turns a form into dicts and lists with both data and errors for each field."""
+        return form_fields_to_dict(self)
 
 
 BaseModelForm = model_form_factory(Form, form_generator=FormGenerator)

--- a/keg_elements/forms/__init__.py
+++ b/keg_elements/forms/__init__.py
@@ -3,10 +3,10 @@ from __future__ import unicode_literals
 
 import functools
 import inspect
-import json
 import logging
 
 import flask
+import flask.json as json  # ensure we use the right json package
 from flask_wtf import Form as BaseForm
 from keg.db import db
 import six


### PR DESCRIPTION
The packages that end up using keg and keg elements should determine
which JSON encoder/decoder to use. This is not as simple as just
checking for simplejson / stdlib json since flask supports completely
overriding the encoders and decords when creating an application.

See http://flask.readthedocs.org/en/latest/api/#module-flask.json for
more details.