### PR TITLE
Improve form help message popovers

### DIFF
--- a/keg_elements/templates/keg_elements/forms/horizontal.html
+++ b/keg_elements/templates/keg_elements/forms/horizontal.html
@@ -29,10 +29,10 @@
         </div>
         {% if field.description %}
           <div class="description">
-            <button type="button" class="btn" data-toggle="popover"
-                    data-content="{{ field.description }}" data-placement="top">
-              ?
-            </button>
+                <a type="button" class="btn btn-default" data-toggle="popover"
+                  title="{{ field.label.text }} Field" data-content="{{ field.description }}"
+                  data-placement="right" data-trigger="focus" tabindex="-1" data-container="body">
+                ?</a>
           </div>
         {% endif %}
     </div>
@@ -92,10 +92,10 @@
         </div>
         {% if field.description %}
           <div class="description">
-            <button type="button" class="btn" data-toggle="popover"
-                    data-content="{{ field.description }}" data-placement="top">
-              ?
-            </button>
+            <a type="button" class="btn btn-default" data-toggle="popover"
+              title="{{ field.label.text }} Field" data-content="{{ field.description }}"
+              data-placement="right" data-trigger="focus" tabindex="-1" data-container="body">
+            ?</a>
           </div>
         {% endif %}
     </div>


### PR DESCRIPTION
This greatly improves the popovers for form elements. 

![screen shot 2015-10-14 at 10 30 08 pm](https://cloud.githubusercontent.com/assets/276212/10503361/2cf59e72-72c3-11e5-8818-7199f62f5589.png)

Note: in order for this to work, this needs to be on the page somewhere.

```javascript
$(function () {
  $('[data-toggle="popover"]').popover()
})
```