### PR TITLE
Improve the logic for when to default a form field to RequiredBoolRadioField

### DIFF
--- a/keg_elements/forms/__init__.py
+++ b/keg_elements/forms/__init__.py
@@ -232,7 +232,7 @@ class FormGenerator(FormGeneratorBase):
 
         is_required_boolean = (field_cls is wtforms.fields.BooleanField
                                and not column.nullable
-                               and (not column.default or not column.server_default))
+                               and not column.default)
 
         if is_required_boolean:
             return RequiredBoolRadioField

--- a/keg_elements/tests/test_forms.py
+++ b/keg_elements/tests/test_forms.py
@@ -122,6 +122,17 @@ class TestRequiredBoolRadioField(FormBase):
         form = self.assert_valid(**{'is_competent': 'False', 'statement_is': 'False'})
 
 
+class TestDefaultTypeOfRequiredBooleanField(FormBase):
+    entity_cls = ents.ThingWithRequiredBoolean
+
+    def test_field_types(self):
+        form = self.compose_meta(csrf_enabled=False)
+        assert type(form.nullable_boolean) == wtf.fields.BooleanField
+        assert type(form.required_boolean) == ke_forms.RequiredBoolRadioField
+        assert type(form.required_boolean_with_default) == wtf.fields.BooleanField
+        assert type(form.required_boolean_with_server_default) == ke_forms.RequiredBoolRadioField
+
+
 class TestFieldMeta(FormBase):
     entity_cls = ents.Thing
 

--- a/kegel_app/model/entities.py
+++ b/kegel_app/model/entities.py
@@ -8,3 +8,14 @@ class Thing(db.Model):
     name = db.Column(db.Unicode(50), nullable=False)
     color = db.Column(db.Unicode)
     scale_check = db.Column(db.Numeric(8, 4))
+
+
+class ThingWithRequiredBoolean(db.Model):
+    __tablename__ = 'required_boolean_table'
+    id = db.Column(db.Integer, primary_key=True)
+
+    nullable_boolean = db.Column(db.Boolean, nullable=True)
+    required_boolean = db.Column(db.Boolean, nullable=False)
+    required_boolean_with_default = db.Column(db.Boolean, nullable=False, default=False)
+    required_boolean_with_server_default = db.Column(db.Boolean, nullable=False,
+                                                     server_default='false')


### PR DESCRIPTION
The logic previously would consider entity fields with default values to still
be required in the UI. However, by its very nature, a `RadioField` with a default value
cannot ever submit a NULL. For this case, we should just use the normal `BooleanField`.