### PR TITLE
Enable readonly and disabled attributes on input and radio fields

### DIFF
--- a/keg_elements/templates/keg_elements/forms/horizontal.html
+++ b/keg_elements/templates/keg_elements/forms/horizontal.html
@@ -48,7 +48,7 @@
             {{ field.label(class_='control-label') }}
         {% endif %}
         <div class="labeled-group">
-        {{ field(class_='form-control', **kwargs) }}
+        {{ field(class_='form-control', disabled=field.flags.disabled, readonly=field.flags.readonly, **kwargs) }}
         {% if field.errors %}
             {% for e in field.errors %}
                 <p class="help-block">{{ e }}</p>
@@ -103,7 +103,13 @@
         {% for value, label, checked in field.iter_choices() %}
             <div class="radio">
                 <label>
-                    <input type="radio" name="{{ field.id }}" id="{{ field.id }}" value="{{ value }}" {% if checked %} checked="checked" {% endif %}>{{ label }}
+                    <input type="radio"
+                           name="{{ field.id }}"
+                           id="{{ field.id }}"
+                           value="{{ value }}"
+                           {{ 'checked' if checked }}
+                           {{ 'disabled' if field.flags.disabled or (field.flags.readonly and not checked) }}>
+                        {{ label }}
                 </label>
             </div>
         {% endfor %}

--- a/keg_elements/tests/test_templates.py
+++ b/keg_elements/tests/test_templates.py
@@ -1,16 +1,20 @@
 from __future__ import absolute_import
 
+import itertools
+
 import keg
 from keg_elements.forms import Form
 from pyquery import PyQuery
-from wtforms import StringField
+from wtforms import RadioField, StringField
 
 
-class TestTemplates(object):
+class TemplateTest(object):
     def render(self, filename, args=None):
         template = keg.current_app.jinja_env.get_template(filename)
         return PyQuery(template.render(**(args or {})))
 
+
+class TestGenericTemplates(TemplateTest):
     def test_form_field_value_macro(self):
         class TestForm(Form):
             test = StringField()
@@ -42,3 +46,95 @@ class TestTemplates(object):
 
         assert response('#static #with-caller #test').text() == 'test-value'
         assert response('#static #with-field-name #test').text() == 'test-value'
+
+
+class TestReadonlyOrDisabledFormRender(TemplateTest):
+    class TestForm(Form):
+        radio_options = ['A', 'B', 'C']
+        radio_choices = [(x, x) for x in radio_options]
+
+        def field_flag(flags):
+            """Creates a no-op validator that has the given field flags."""
+            class FlaggedValidator(object):
+                field_flags = flags
+
+                def __call__(self, form, field):
+                    pass
+
+            return FlaggedValidator()
+
+        text = StringField('Text')
+        text_readonly = StringField('Read-only Text', [field_flag({'readonly'})])
+        text_disabled = StringField('Disabled Text', [field_flag({'disabled'})])
+
+        radio = RadioField('Radio', choices=radio_choices)
+        radio_readonly = RadioField('Read-only Radio', [field_flag({'readonly'})],
+                                    choices=radio_choices)
+        radio_disabled = RadioField('Disabled Radio', [field_flag({'disabled'})],
+                                    choices=radio_choices)
+
+    def test_input_fields(self):
+        def assert_string_field_attr(field_name, attr_name, attr_value):
+            response = self.render('generic-input-field.html', {
+                'form': self.TestForm(**{field_name: 'some-data'}),
+                'field_name': field_name
+            })
+
+            assert response('#static #' + field_name).attr(attr_name) is None
+            assert response('#dynamic #' + field_name).attr(attr_name) == attr_value
+
+        assert_string_field_attr('text', 'readonly', None)
+        assert_string_field_attr('text', 'disabled', None)
+
+        assert_string_field_attr('text_readonly', 'readonly', 'readonly')
+        assert_string_field_attr('text_readonly', 'disabled', None)
+
+        assert_string_field_attr('text_disabled', 'readonly', None)
+        assert_string_field_attr('text_disabled', 'disabled', 'disabled')
+
+    def render_radio_field(self, field_name, field_value):
+        return self.render('generic-radio-field.html', {
+            'form': self.TestForm(**{field_name: field_value}),
+            'field_name': field_name
+        })
+
+    def test_normal_radio(self):
+        response = self.render_radio_field('radio', 'A')
+
+        assert response('#dynamic input[value=A]').attr.checked == 'checked'
+
+        for root, label in itertools.product({'#static', '#dynamic'},
+                                             self.TestForm.radio_options):
+            sel = '{} input[value={}]'.format(root, label)
+            response(sel).attr.readonly is None
+            response(sel).attr.disabled is None
+            response(sel).attr.readonly is None
+            response(sel).attr.disabled is None
+
+    def test_readonly_radio(self):
+        response = self.render_radio_field('radio_readonly', 'B')
+        radio_at_value = lambda value: response('#dynamic input[value={}]'.format(value))
+
+        assert radio_at_value('B').attr.checked == 'checked'
+        assert not radio_at_value('A').attr.readonly
+        assert not radio_at_value('B').attr.readonly
+        assert not radio_at_value('C').attr.readonly
+        assert radio_at_value('A').attr.disabled
+        assert not radio_at_value('B').attr.disabled
+        assert radio_at_value('C').attr.disabled
+
+        assert response('#static p').text() == 'B'
+
+    def test_disabled_radio(self):
+        response = self.render_radio_field('radio_disabled', 'C')
+        radio_at_value = lambda value: response('#dynamic input[value={}]'.format(value))
+
+        assert radio_at_value('C').attr.checked == 'checked'
+        assert not radio_at_value('A').attr.readonly
+        assert not radio_at_value('B').attr.readonly
+        assert not radio_at_value('C').attr.readonly
+        assert radio_at_value('A').attr.disabled
+        assert radio_at_value('B').attr.disabled
+        assert radio_at_value('C').attr.disabled
+
+        assert response('#static p').text() == 'C'

--- a/kegel_app/templates/generic-input-field.html
+++ b/kegel_app/templates/generic-input-field.html
@@ -1,0 +1,10 @@
+{% import 'keg_elements/forms/horizontal.html' as dynamic_render %}
+{% import 'keg_elements/forms/horizontal_static.html' as static_render %}
+
+<div id="dynamic">
+    {{ dynamic_render.field(form[field_name]) }}
+</div>
+
+<div id="static">
+    {{ static_render.field(form[field_name]) }}
+</div>

--- a/kegel_app/templates/generic-radio-field.html
+++ b/kegel_app/templates/generic-radio-field.html
@@ -1,0 +1,10 @@
+{% import 'keg_elements/forms/horizontal.html' as dynamic_render %}
+{% import 'keg_elements/forms/horizontal_static.html' as static_render %}
+
+<div id="dynamic">
+    {{ dynamic_render.radio_field(form[field_name]) }}
+</div>
+
+<div id="static">
+    {{ static_render.radio_field(form[field_name]) }}
+</div>


### PR DESCRIPTION
The approach is to respect validator flags "readonly" and "disabled". They mean the same thing as they do in HTML: readonly means no changing, disabled means no interaction whatsoever (and not submitted in form submit).

For radio fields, "readonly" means that all but the selected options are disabled (so you can only select the already-selected option, if any). "disabled" means all options get disabled, even the checked one.

For select fields, you need to specify "disabled" if you don't want the user to be able to select from the dropdown.

Checkboxes are more complicated and may come later.