### PR TITLE
Refactor dynamic template field for easier reuse

### DIFF
--- a/keg_elements/templates/keg_elements/forms/horizontal.html
+++ b/keg_elements/templates/keg_elements/forms/horizontal.html
@@ -8,10 +8,12 @@
     Example usage:
         {{ horz_form.field(form.email, placeholder='Input email', type='email') }}
 #}
-{% macro div_form_group(field, caller_kwargs) -%}
-     <div class="form-group {% if field.flags.required %}required{% endif %} {% if field.errors %}has-error{% endif %}
-        {{caller_kwargs.pop('class_', '') }} ">
-{%- endmacro%}
+
+{% macro div_form_group(field) -%}
+    <div class="form-group {{ 'required' if field.flags.required }} {{ 'has-error' if field.errors }} {{ kwargs.get('class_', '') }}">
+        {{ caller(**kwargs) }}
+    </div>
+{%- endmacro %}
 
 {% macro description(field) -%}
   <div class="description">
@@ -43,23 +45,27 @@
         e.preventDefault();
     });
 #}
-    {{div_form_group(field, kwargs)}}
-        {% if (field.type != 'HiddenField' and field.type !='CSRFTokenField') and label_visible %}
+    {% call div_form_group(field, **kwargs) %}
+        {% if (field.type != 'HiddenField' and field.type != 'CSRFTokenField') and label_visible %}
             {{ field.label(class_='control-label') }}
         {% endif %}
         <div class="labeled-group">
-        {{ field(class_='form-control', disabled=field.flags.disabled, readonly=field.flags.readonly, **kwargs) }}
-        {% if field.errors %}
-            {% for e in field.errors %}
-                <p class="help-block">{{ e }}</p>
-            {% endfor %}
-        {% endif %}
+            {{ field_widget(field, **kwargs) }}
         </div>
         {% if field.description %}
             {{ description(field) }}
         {% endif %}
-    </div>
+    {% endcall %}
 {%- endmacro %}
+
+{% macro field_widget(field) %}
+    {{ field(class_='form-control', disabled=field.flags.disabled, readonly=field.flags.readonly, **kwargs) }}
+    {% if field.errors %}
+        {% for e in field.errors %}
+            <p class="help-block">{{ e }}</p>
+        {% endfor %}
+    {% endif %}
+{% endmacro %}
 
 {# Renders checkbox fields since they are represented differently in bootstrap
     Params:
@@ -71,18 +77,18 @@
         {{ horiz_form.checkbox_field(form.remember_me) }}
  #}
 {% macro checkbox_field(field) -%}
-    {{div_form_group(field, kwargs)}}
-      <div class="unlabeled-group checkbox">
-        <label>
-            {{ field(type='checkbox', **kwargs) }} {{ field.label }}
-        </label>
-        {% if field.errors %}
-            {% for e in field.errors %}
-                <p class="help-block">{{ e }}</p>
-            {% endfor %}
-        {% endif %}
-      </div>
-    </div>
+    {% call div_form_group(field, **kwargs) %}
+        <div class="unlabeled-group checkbox">
+            <label>
+                {{ field(type='checkbox', **kwargs) }} {{ field.label }}
+            </label>
+            {% if field.errors %}
+                {% for e in field.errors %}
+                    <p class="help-block">{{ e }}</p>
+                {% endfor %}
+            {% endif %}
+        </div>
+    {% endcall %}
 {%- endmacro %}
 
 {# Renders radio field
@@ -95,7 +101,7 @@
         {{ horiz_form.radio_field(form.answers) }}
  #}
 {% macro radio_field(field, label_visible=true) -%}
-    {{div_form_group(field, kwargs)}}
+    {% call div_form_group(field, **kwargs) %}
         {% if label_visible %}
             {{ field.label(class_='control-label') }}
         {% endif %}
@@ -122,7 +128,7 @@
         {% if field.description %}
             {{ description(field) }}
         {% endif %}
-    </div>
+    {% endcall %}
 {%- endmacro %}
 
 {% macro submit_group(action_text='Submit', btn_class='btn btn-primary', cancel_url='') -%}

--- a/keg_elements/templates/keg_elements/forms/horizontal_static.html
+++ b/keg_elements/templates/keg_elements/forms/horizontal_static.html
@@ -9,22 +9,23 @@
         {{ horz_form.field(form.email, placeholder='Input email', type='email') }}
 #}
 
+{% macro div_form_group(field) -%}
+    <div class="form-group {{ class_ or '' }}">
+        {{ caller(**kwargs) }}
+    </div>
+{%- endmacro %}
+
+
 {% macro identity(value) %}{{ value }}{% endmacro %}
 
 {% macro field(field, value_macro=identity, label_visible=true) -%}
     {% if field.type != 'HiddenField' and field.type !='CSRFTokenField' %}
-        <div class="form-group {{ kwargs.pop('class_', '') }}">
+        {% call div_form_group(field, **kwargs) %}
             {% if label_visible %}
                 {{ field.label(class_='control-label') }}
             {% endif %}
             <div class="labeled-group">
-                <p id="{{ field.id }}" class="form-control-static">
-                    {%- if field.type == 'SelectField' -%}
-                        {{ value_macro(field.selected_choice_label) }}
-                    {%- else -%}
-                        {{ value_macro(field.data) }}
-                    {%- endif -%}
-                </p>
+                {{ field_widget(field, value_macro=value_macro, **kwargs) }}
             </div>
             {% if field.description %}
               <div class="description">
@@ -34,10 +35,20 @@
                 </button>
               </div>
             {% endif %}
-        </div>
+        {% endcall %}
     {% endif %}
 {%- endmacro %}
 
+{% macro field_widget(field, value_macro=identity) %}
+    {{ '' if kwargs }} {# use kwargs so it is accepted #}
+    <p id="{{ field.id }}" class="form-control-static">
+        {%- if field.type == 'SelectField' -%}
+            {{ value_macro(field.selected_choice_label) }}
+        {%- else -%}
+            {{ value_macro(field.data) }}
+        {%- endif -%}
+    </p>
+{% endmacro %}
 
 {# Renders radio field
     Params:
@@ -49,7 +60,7 @@
         {{ horiz_form.radio_field(form.answers) }}
  #}
 {% macro radio_field(field, label_visible=true) -%}
-    <div class="form-group {{ kwargs.pop('class_', '') }}">
+    {% call div_form_group(field, **kwargs) %}
         {% if label_visible %}
             {{ field.label(class_='control-label') }}
         {% endif %}
@@ -68,14 +79,14 @@
             </button>
           </div>
         {% endif %}
-    </div>
+    {% endcall %}
 {%- endmacro %}
 
 {% macro submit_group(action_text='Done', btn_class='btn btn-primary', cancel_url='') -%}
     <div class="form-group">
-      <div class="unlabeled-group">
-        <a href="{{cancel_url}}" class="{{ btn_class }}">{{ action_text }}</a>
-      </div>
+        <div class="unlabeled-group">
+          <a href="{{cancel_url}}" class="{{ btn_class }}">{{ action_text }}</a>
+        </div>
     </div>
 {%- endmacro %}
 

--- a/keg_elements/tests/test_templates.py
+++ b/keg_elements/tests/test_templates.py
@@ -138,3 +138,22 @@ class TestReadonlyOrDisabledFormRender(TemplateTest):
         assert radio_at_value('C').attr.disabled
 
         assert response('#static p').text() == 'C'
+
+
+class TestFieldMacros(TemplateTest):
+    class TestForm(Form):
+        myfield = StringField('My Field')
+
+    def test_div_form_group(self):
+        response = self.render('field-macros.html', {
+            'form': self.TestForm(myfield='My Data'),
+            'field_name': 'myfield',
+            'form_group_class': None,
+            'field_kwargs': {},
+        })
+
+        assert response('#dynamic #div_form_group div.form-group').text() == 'Contents'
+        assert response('#static  #div_form_group div.form-group').text() == 'Contents'
+
+        assert response('#dynamic #field_widget #myfield')[0].value == 'My Data'
+        assert response('#static  #field_widget #myfield').text() == 'My Data'

--- a/kegel_app/templates/field-macros.html
+++ b/kegel_app/templates/field-macros.html
@@ -1,0 +1,26 @@
+{% import 'keg_elements/forms/horizontal.html' as dynamic_render %}
+{% import 'keg_elements/forms/horizontal_static.html' as static_render %}
+
+<div id="dynamic">
+    <div id="div_form_group">
+        {% call dynamic_render.div_form_group(form[field_name], **field_kwargs) %}
+            Contents
+        {% endcall %}
+    </div>
+
+    <div id="field_widget">
+        {{ dynamic_render.field_widget(form[field_name], **field_kwargs) }}
+    </div>
+</div>
+
+<div id="static">
+    <div id="div_form_group">
+        {% call static_render.div_form_group(form[field_name], **field_kwargs) %}
+            Contents
+        {% endcall %}
+    </div>
+
+    <div id="field_widget">
+        {{ static_render.field_widget(form[field_name], **field_kwargs) }}
+    </div>
+</div>


### PR DESCRIPTION
I have repeatedly found myself wanting to *slightly* customize how a form field is rendered, but the macros, as they were written, basically offered an "all or nothing" API. I split it up into a few separate stages so that my code doesn't have to recreate as much that's already in KegElements. I mimicked my changes in the static form macros as well. The test verifies that the two interfaces are identical so that the code works in both dynamic or static cases.