### PR TITLE
Fix descriptions on checkbox fields when rendered implicitly by a form

### DIFF
--- a/keg_elements/templates/keg_elements/forms/horizontal.html
+++ b/keg_elements/templates/keg_elements/forms/horizontal.html
@@ -88,6 +88,9 @@
                 {% endfor %}
             {% endif %}
         </div>
+        {% if field.description %}
+            {{ description(field) }}
+        {% endif %}
     {% endcall %}
 {%- endmacro %}
 

--- a/kegel_app/templates/generic-form.html
+++ b/kegel_app/templates/generic-form.html
@@ -1,0 +1,10 @@
+{% import 'keg_elements/forms/horizontal.html' as dynamic_render %}
+{% import 'keg_elements/forms/horizontal_static.html' as static_render %}
+
+<div id="dynamic">
+    {{ dynamic_render.form(form) }}
+</div>
+
+<div id="static">
+    {{ static_render.form(form) }}
+</div>


### PR DESCRIPTION
I don't really understand why checkboxes are rendered by two different macros depending on how you call things...but regardless this fixes the issue that existed in one of those cases.

I also fixed a warning by renaming a few classes.