### PR TITLE
Fix spelling errors

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -131,13 +131,13 @@ Changelog
 ------------------
 
 * FEATURE: Port ``MethodsMixin`` with a number of helpful functions when working with
-  SQLAlchemy ORM entites. (GH-49_, GH-51_)
+  SQLAlchemy ORM entities. (GH-49_, GH-51_)
 * FEATURE: Add a new TimeZone Column. (GH-50_)
 
 * MAINTENANCE: Provide better testing support for polymorphic SQLAlchemy
   ORM entities. (GH-47_)
 
-* BUG: Fix descripions when implicitly rendering checkboxes (GH-48_)
+* BUG: Fix descriptions when implicitly rendering checkboxes (GH-48_)
 
 .. _GH-50: https://github.com/level12/keg-elements/pull/50
 .. _GH-51: https://github.com/level12/keg-elements/pull/51
@@ -165,9 +165,9 @@ Changelog
 -----
 
 * Allow static renders to be configured with custom macros. (GH-34)
-* Syncronize static templates with dynamic templates. (GH-31)
+* Synchronize static templates with dynamic templates. (GH-31)
 * You can now give a field a description with a string or callback. (GH-23, GH-22)
-* Introduced a RequiredBoolReadioField for use with boolean columns. (GH-25)
+* Introduced a RequiredBoolRadioField for use with boolean columns. (GH-25)
 * Support randomly filling EmailTypes. (GH-24)
 * Support additional parameters for randomizing integers. (GH-19)
 * ``testing_create`` will randomly select a boolean value for SQLAlchemy boolean
@@ -180,7 +180,7 @@ Changelog
 * ``MethodsMixin`` has a new ``ensure`` method. (e5687ed)
 
 
-* Fix bug where static renderes whould not output the label. (GH-33)
+* Fix bug where static renders would not output the label. (GH-33)
 * Fix property names when using automatic test cases. (GH-29)
 * Fix issue where we wouldn't use a consistent json parser. (GH-13)
 * Fix a bug where polymorphic columns are included in ``testing_create``. (147c23)

--- a/keg_elements/db/utils.py
+++ b/keg_elements/db/utils.py
@@ -68,8 +68,8 @@ def _validate_unique_msg(dialect, msg):
 
 def randemail(length, randomizer=randchars):
     """Generate a random email address at the given length.
-    :param length: must be at least 7 or the funuction will throw a ValueError.
-    :param randomzer: is a function for generating random characters. It must have an identical
+    :param length: must be at least 7 or the function will throw a ValueError.
+    :param randomizer: is a function for generating random characters. It must have an identical
                       interface to `randchars`. The default function is `randchars`.
     """
     if length < 7:
@@ -146,9 +146,9 @@ class CollectionUpdater(object):
                 self.collection.append(child)
 
             self.keep_children.add(child)
-        self.remove_umodified()
+        self.remove_unmodified()
 
-    def remove_umodified(self):
+    def remove_unmodified(self):
         remove_children = [child for child in self.collection if child not in self.keep_children]
         for child in remove_children:
             self.collection.remove(child)

--- a/keg_elements/encoding.py
+++ b/keg_elements/encoding.py
@@ -2,7 +2,7 @@ import six
 
 
 def force_bytes(s, encoding='utf-8', errors='strict'):
-    """Force objects to byte respresentation"""
+    """Force objects to byte representation"""
     # Handle the common case first for performance reasons.
     if isinstance(s, bytes):
         if encoding == 'utf-8':

--- a/keg_elements/forms/__init__.py
+++ b/keg_elements/forms/__init__.py
@@ -179,8 +179,8 @@ class SelectField(SelectFieldBase):
         Provides helpful features above wtforms_components SelectField which it is based on:
 
         1) Adds a blank choice by default at the front of the choices.  This results in your user
-           being forced to select something if the field is required, which avoids unintial
-           deaulting of the first value in the field getting submitted.
+           being forced to select something if the field is required, which avoids initial
+           defaulting of the first value in the field getting submitted.
         2) The coerce function used for the choices will automatically convert to int if possible,
            falling back to unicode if the value is not an integer.
     """

--- a/keg_elements/testing.py
+++ b/keg_elements/testing.py
@@ -82,7 +82,7 @@ class EntityBase(object):
         for col_check in self.column_check_generator():
             col = getattr(self.entity_cls, col_check.name)
             assert col.nullable != col_check.required, \
-                'Expected colum "{}" to match null requirement'.format(col.name)
+                'Expected column "{}" to match null requirement'.format(col.name)
 
     def test_column_unique(self):
         for col_check in self.column_check_generator():

--- a/keg_elements/tests/test_db_mixins.py
+++ b/keg_elements/tests/test_db_mixins.py
@@ -17,7 +17,7 @@ class TestDefaultColsMixin:
     def setup_method(self, fn):
         ents.Thing.delete_cascaded()
 
-    def test_default_odering(self):
+    def test_default_ordering(self):
         thing1 = ents.Thing.testing_create(id=6)
         thing2 = ents.Thing.testing_create(id=5)
         thing3 = ents.Thing.testing_create(id=7)
@@ -137,7 +137,7 @@ class TestMethodsMixin:
         with pytest.raises(sa.orm.exc.MultipleResultsFound):
             ents.Thing.get_where(ents.Thing.color == 'black')
 
-    def test_pairs_takes_name_and_value_and_retuns_list_of_tuples(self):
+    def test_pairs_takes_name_and_value_and_returns_list_of_tuples(self):
         thing1 = ents.Thing.testing_create(name='A', color='orange')
         thing2 = ents.Thing.testing_create(name='B', color='black')
 

--- a/keg_elements/tests/test_forms/test_form.py
+++ b/keg_elements/tests/test_forms/test_form.py
@@ -183,7 +183,7 @@ class TestFieldMeta(FormBase):
         assert form.validate()
 
         form = self.compose_meta(fields_meta_cls=ExtraValidatorsFieldsMeta, csrf_enabled=False,
-                                 name='Test', color='muave')
+                                 name='Test', color='mauve')
         assert not form.validate()
         assert set(form.color.errors) == {'Not a ROY color'}
 


### PR DESCRIPTION
Noticed the "colum" one during testing keg-auth changes, it was driving me crazy, figured I'd fix the rest while I was in there.

NOTE TO REVIEWER: I'm not 100% sure that `remove_umodified` was incorrect. It seems like this is supposed to be 'unmodified', but I suppose it's possible that 'umodified' has a meaning internal to the code (though if it does, that meaning isn't immediate obvious from looking it over).

Fixes #96