### PR TITLE
Model Form Generator Should Exclude Create/Update Timestamp Fields

### DIFF
--- a/keg_elements/tests/test_forms/test_form.py
+++ b/keg_elements/tests/test_forms/test_form.py
@@ -654,3 +654,12 @@ class TestFormLevelValidation(FormBase):
         form = self.assert_valid(num1=6, num2=7, num3=50, form_cls=SubclassForm)
         assert form.form_errors == []
         assert form.all_errors == ({}, [])
+
+
+class TestExcludesDatetimes(FormBase):
+    entity_cls = ents.Thing
+
+    def test_exclude_default_cols(self):
+        form = self.compose_meta()
+        assert 'updated_utc' not in form.fields_todict()
+        assert 'created_utc' not in form.fields_todict()


### PR DESCRIPTION
Commit 95e26a6c added logic in the form generator to exclude ArrowType fields with default values by default (see include_datetimes_with_default at https://wtforms-alchemy.readthedocs.io/en/latest/configuration.html). I added a test that verifies updated_utc and created_utc are excluded automatically. This should be sufficient because it seems the case where include_datetimes_with_default would be set to true is rare and datetime fields with defaults can specifically included with the meta include attribute.

Fixes #59