### PR TITLE
add RelationshipSelect fields with model generation for single select

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist
 coverage.xml
 /.eggs
 Pipfile.lock
+tempfile.txt

--- a/keg_elements/db/utils.py
+++ b/keg_elements/db/utils.py
@@ -8,6 +8,7 @@ import sqlalchemy as sa
 from sqlalchemy.sql import expression
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.types import DateTime
+import sqlalchemy_utils as sautils
 
 from blazeutils.strings import randchars
 
@@ -42,6 +43,14 @@ def no_autoflush(wrapped, instance, args, kwargs):
         return wrapped(*args, **kwargs)
     finally:
         db.session.autoflush = autoflush
+
+
+def has_column(orm_cls_or_table, column_name):
+    for column in sautils.get_columns(orm_cls_or_table):
+        if column.key == column_name:
+            return True
+
+    return False
 
 
 def random_numeric(column):


### PR DESCRIPTION
- add generation option for include_required_foreign_keys
- one-to-many FK relationships will be loaded as selects with coerced values
- many-to-many relationships may be specified as multiselects with ORM data loading and value matching (just no autoloading on this yet)

fixes #8