### PR TITLE
Fix wrong package name in instructions

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -10,7 +10,7 @@ Installation
 ------------
 
 - Bare functionality: ``pip install kegelements``
-- Internationalization extensions: ``pip install keg-auth[i18n]``
+- Internationalization extensions: ``pip install kegelements[i18n]``
 
 
 .. _gs-templates:


### PR DESCRIPTION
`pip install` instructions reference wrong package