### PR TITLE
don't duplicate radio input ids

### DIFF
--- a/keg_elements/templates/keg_elements/forms/horizontal.html
+++ b/keg_elements/templates/keg_elements/forms/horizontal.html
@@ -174,7 +174,7 @@
                 <label>
                     <input type="radio"
                            name="{{ field.id }}"
-                           id="{{ field.id }}"
+                           id="{{ field.id }}-{{ value | lower }}"
                            value="{{ value }}"
                            {{ 'checked' if checked }}
                            {{ 'disabled' if field.flags.disabled or (field.flags.readonly and not checked) }}

--- a/keg_elements/templates/keg_elements/forms/horizontal_b4.html
+++ b/keg_elements/templates/keg_elements/forms/horizontal_b4.html
@@ -196,7 +196,7 @@
                 <label>
                     <input type="radio"
                            name="{{ field.id }}"
-                           id="{{ field.id }}"
+                           id="{{ field.id }}-{{ value | lower }}"
                            value="{{ value }}"
                            {{ 'checked' if checked }}
                            {{ 'disabled' if field.flags.disabled or (field.flags.readonly and not checked) }}


### PR DESCRIPTION
fixes #156 

Used `lower` filter to convert ids like  "featured-True" and "gender-Male" to "featured-true" and "gender-male." Could have also used `loop.index0`, but I opted to use the value like Ben suggested as it lends itself to more explicit targeting in tests, etc. IMO.