### PR TITLE
update radio field to use correct b4 classes for validation

### DIFF
--- a/keg_elements/templates/keg_elements/forms/horizontal_b4.html
+++ b/keg_elements/templates/keg_elements/forms/horizontal_b4.html
@@ -192,20 +192,21 @@
         {% endif %}
         <div class="labeled-group">
         {% for value, label, checked in field.iter_choices() %}
-            <div class="radio">
-                <label>
-                    <input type="radio"
-                           name="{{ field.id }}"
-                           id="{{ field.id }}"
-                           value="{{ value }}"
-                           {{ 'checked' if checked }}
-                           {{ 'disabled' if field.flags.disabled or (field.flags.readonly and not checked) }}
-                           tabIndex="{{tabIndex}}">
-                        {{ label }}
-                </label>
+            {% set input_id = field.id ~ '-' ~ loop.index0 %}
+            <div class="form-check">
+                <input type="radio"
+                    name="{{ field.id }}"
+                    id="{{ input_id }}"
+                    class='form-check-input{{' is-invalid' if field.errors }}'
+                    value="{{ value }}"
+                    {{ 'checked' if checked }}
+                    {{ 'disabled' if field.flags.disabled or (field.flags.readonly and not checked) }}
+                    {{ 'required' if field.flags.required }}
+                    tabIndex="{{tabIndex}}">
+                <label class="form-check-label" for="{{ input_id }}">{{ label }}</label>
+                {% if loop.last %}{{ field_errors(field) }}{% endif %}
             </div>
         {% endfor %}
-        {{ field_errors(field) }}
         </div>
         {% if field.description %}
             {{ description(field) }}


### PR DESCRIPTION
May fix #156 for the b4 template. Not meant to make a final decision on it. It was necessary to stop using label/input shorthand to get the bootstrap validation styling to work:

> Due to constraints in how CSS works, we cannot (at present) apply styles to a `<label>` that comes before a form control in the DOM without the help of custom JavaScript.

https://getbootstrap.com/docs/4.6/components/forms/#how-it-works