### PR TITLE
ensure oid on edit method is not flagged by kwargs_match_entity

### DIFF
--- a/keg_elements/db/mixins.py
+++ b/keg_elements/db/mixins.py
@@ -192,7 +192,7 @@ class MethodsMixin:
     @might_flush
     @kwargs_match_entity
     @classmethod
-    def edit(cls, oid=None, **kwargs):
+    def edit(cls, _oid=None, **kwargs):
         """Edit an object in session with the kwargs, and optionally flush or commit.
 
         :param oid: the object identifier, normally the primary key
@@ -201,9 +201,9 @@ class MethodsMixin:
         :return: entity instance edited and optionally flushed/committed
         """
         try:
-            primary_keys = oid or [kwargs.get(x.name)
-                                   for x in cls.primary_keys()
-                                   if x is not None]
+            primary_keys = _oid or [kwargs.get(x.name)
+                                    for x in cls.primary_keys()
+                                    if x is not None]
         except KeyError:
             raise AttributeError(_('No primary key was found in `oid` or `kwargs`'
                                    ' for which to retrieve the object to edit'))

--- a/keg_elements/i18n/babel.cfg
+++ b/keg_elements/i18n/babel.cfg
@@ -1,4 +1,3 @@
 [python: **.py]
 [jinja2: templates/**.html]
-extensions=jinja2.ext.autoescape,jinja2.ext.with_
 [javascript: **.js]

--- a/keg_elements/tests/test_db_mixins.py
+++ b/keg_elements/tests/test_db_mixins.py
@@ -74,7 +74,7 @@ class TestMethodsMixin:
     def test_edit(self):
         thing1 = ents.Thing.testing_create()
 
-        ents.Thing.edit(thing1.id, name='edited')
+        ents.Thing.edit(_oid=thing1.id, name='edited')
         assert thing1.name == 'edited'
 
         with pytest.raises(AttributeError):


### PR DESCRIPTION
The `@kwargs_match_entity` decorator used on the `edit` method on `MethodsMixin` https://github.com/level12/keg-elements/blob/168e70af2b49bfd3f1e97705b86d158821e5d2ad/keg_elements/db/mixins.py#L193 will throw an error when `oid` is passed in as a kwarg (because `oid` is not a column or relationship on the entity). We don't catch this in the tests because we pass the `oid` in without the keyword: https://github.com/level12/keg-elements/blob/168e70af2b49bfd3f1e97705b86d158821e5d2ad/keg_elements/tests/test_db_mixins.py#L77

I changed the `oid` kwarg to `_oid` in the method definition because the decorator ignores kwargs starting with an underscore. This shouldn't be a breaking change because anyone passing in `oid` using the kwarg would have been getting an error anyway (unless they happened to have an `oid` column/relationship on the entity).